### PR TITLE
Drop builds for node 12,13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-        node-version: [12.x, 13.x, 14.x, 15.x, 16.x]
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
 
     steps:
       - name: Git checkout and install Chrome

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [14.x, 15.x, 16.x]
 
     steps:
       - name: Git checkout and install Chrome

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Cucumber steps (step definitions) written with WebdriverIO for end-to-end (e2e) 
         <tr>
             <td>12.x</td>
             <td rowspan=5><p>6.x</p><p>7.x</p></td>
-            <td rowspan=5><p>5.x, 6.x</p><p>7.x</p></td>
+            <td rowspan=5><p>5.x</p><p>6.x</p><p>7.x</p></td>
         </tr>
         <tr>
             <td>13.x</td>


### PR DESCRIPTION
Not adding node 17,18 for now because of an opened bug in WebdriverIO - https://github.com/webdriverio/webdriverio/issues/8279